### PR TITLE
Fix History Table display

### DIFF
--- a/frontend/src/containers/Profile/Alts/Table.tsx
+++ b/frontend/src/containers/Profile/Alts/Table.tsx
@@ -18,7 +18,9 @@ const Table = styled(TableMui)({
   '& tbody tr:hover': {
     backgroundColor: 'rgb(21, 128, 61, 0.25)',
   },
-
+  '& tr': {
+    height: '40px !important',
+  },
   '& th': {
     padding: '8px !important',
   },

--- a/frontend/src/containers/Profile/Armory.tsx
+++ b/frontend/src/containers/Profile/Armory.tsx
@@ -24,13 +24,16 @@ const Armory = ({ player, loading, updatePlayer }: IProps) => {
   return (
     <div className="flex flex-col lg:flex-row gap-2 md:gap-4 rounded-lg">
       {breakpoint === 'lg' && (
-        <div className="flex flex-col gap-2 md:gap-4 lg:w-[320px]">
+        <div className="flex flex-col gap-2 md:gap-4 lg:w-[300px] lg:min-w-[300px]">
           <PlayerDesktop player={player} />
           <TitlesHistory player={player} />
         </div>
       )}
 
-      <div className="flex flex-col gap-2 grow lg:self-start rounded-lg">
+      <div
+        className="flex flex-col gap-2 grow lg:self-start rounded-lg"
+        style={breakpoint === 'lg' ? { maxWidth: 'calc(100% - 300px)' } : {}}
+      >
         {breakpoint === 'md' && <PlayerMobile player={player} />}
         <PlayerHeader player={player} updatePlayer={updatePlayer} loading={loading} />
         <PvpBrackets player={player} />

--- a/frontend/src/containers/Profile/History/BracketTabs.tsx
+++ b/frontend/src/containers/Profile/History/BracketTabs.tsx
@@ -12,14 +12,16 @@ const arenaAndRbg = [
   { name: 'BATTLEGROUNDS', title: 'RBG' },
 ];
 
-const Tab = styled((props: TabProps) => <MuiTab disableRipple {...props} />)(({ theme }) => ({
+const Tab = styled((props: TabProps) => <MuiTab {...props} />)(({ theme }) => ({
   textTransform: 'none',
+  minWidth: 0,
+  [theme.breakpoints.up('sm')]: {
+    minWidth: 0,
+  },
+
   fontWeight: theme.typography.fontWeightRegular,
   fontSize: theme.typography.pxToRem(14),
-  marginRight: theme.spacing(1),
-  height: '32px',
-  minHeight: '32px',
-  minWidth: 'auto',
+  padding: '8px 16px',
 }));
 
 const BracketTabs = ({
@@ -45,6 +47,8 @@ const BracketTabs = ({
       className="!min-h-[38px]"
       value={value}
       onChange={onChange}
+      variant="scrollable"
+      scrollButtons={false}
       textColor="primary"
       indicatorColor="primary"
     >

--- a/frontend/src/containers/Profile/History/Table.tsx
+++ b/frontend/src/containers/Profile/History/Table.tsx
@@ -22,7 +22,7 @@ const Table = styled(TableMui)({
     padding: '4px !important',
   },
   '& tr td,th': {
-    borderBottom: 'none',
+    borderColor: '#37415180',
   },
 });
 
@@ -106,7 +106,7 @@ const HistoryTable = ({ columns, records = [], isMobile }: IProps) => {
   );
 
   return (
-    <div className="relative bg-[#030303e6]">
+    <div className="relative bg-[#030303e6] w-full w-max-full">
       {<TableContainer>{renderTable()}</TableContainer>}
       {!records.length && (
         <div className="min-h-[100px] flex justify-center items-center">

--- a/frontend/src/containers/Profile/History/columns.tsx
+++ b/frontend/src/containers/Profile/History/columns.tsx
@@ -108,7 +108,7 @@ const renderServerTime = ({ record }: IParams, player: IPlayer) => {
       .format('MMM DD, YYYY - hh:mm A');
   };
 
-  return <span>{getDate(record.timestamp)}</span>;
+  return <span className="whitespace-nowrap">{getDate(record.timestamp)}</span>;
 };
 
 const shouldRenderWWho = (bracket: string) => {

--- a/frontend/src/containers/Profile/History/index.tsx
+++ b/frontend/src/containers/Profile/History/index.tsx
@@ -39,13 +39,13 @@ const GamingHistory = ({ player }: { player: IPlayer }) => {
   }, [player, bracket, value]);
 
   return (
-    <div className="flex flex-col md:px-3 py-4 border border-solid border-[#37415180] rounded-lg bg-[#030303e6]">
+    <div className="flex flex-col py-2 md:px-3 border border-solid border-[#37415180] rounded-lg bg-[#030303e6] ">
       <div className="flex justify-between items-center px-3 md:px-0">
-        <span className="text-2xl">Gaming History</span>
+        <span className="text-2xl mr-4">History</span>
         <BracketTabs player={player} onChange={handleChange} value={value} />
       </div>
 
-      <hr className="h-px md:my-2 bg-[#37415180] border-0" />
+      <hr className="h-px md:mb-2 bg-[#37415180] border-0" />
 
       <Table
         columns={tableColumns(player, value)}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -12,7 +12,7 @@ const appTheme = createTheme({
   palette: {
     primary: {
       light: '#757ce8',
-      main: '#3f50b5',
+      main: '#60A5FACC',
       dark: '#002884',
       contrastText: '#fff',
     },


### PR DESCRIPTION
- Add horizontal scroll for the History table. Scroll will appear on the mobile devices and under the "All" tab if player have RGB games
- Make History tabs scrollable so user can access hidden tabs on the mobile device
- Change primary color
- Rename section Gaming History -> History

![image](https://github.com/Sammers21/pvpqnet/assets/31778230/c07da1bf-cb2a-4292-ad0f-b9041dec52df)
